### PR TITLE
Harvester metrics wrong when the host name/ip is repeated

### DIFF
--- a/monitor/collectors/rpc_collector.py
+++ b/monitor/collectors/rpc_collector.py
@@ -108,7 +108,7 @@ class RpcCollector(Collector):
             harvesters = await self.farmer_client.get_harvesters()
             ts = datetime.now()
             for harvester in harvesters["harvesters"]:
-                host = harvester["connection"]["host"]
+                host = "{}/{}".format(harvester["connection"]["host"], harvester["connection"]["node_id"][0:6])
                 plots = harvester["plots"]
                 og_plots = [plot for plot in plots if plot["pool_contract_puzzle_hash"] is None]
                 portable_plots = [


### PR DESCRIPTION
When multiple harvesters have the same domain name or IP (when behind a router) we only get the last harvester in the metric, because we keep replacing the earlier ones.
By appending the node_id to the host they become unique and correctly reported.

As a bonus those node IDs are the same ones identifying the harvesters in flexpool so you can track which is which.

![image](https://user-images.githubusercontent.com/2863796/127785716-640bb056-ced2-4763-88a7-276177bcdb59.png)
