### PR TITLE
Add option to disable price collector and improve configuration code

### DIFF
--- a/config-example.json
+++ b/config-example.json
@@ -4,6 +4,7 @@
         "refresh_interval_seconds": 10
     },
     "price_collector": {
+        "enable": true,
         "refresh_interval_seconds": 10
     },
     "notifications": {

--- a/monitor/__main__.py
+++ b/monitor/__main__.py
@@ -1,5 +1,4 @@
 import asyncio
-import json
 import logging
 import sys
 from asyncio.queues import Queue
@@ -10,14 +9,14 @@ from chia.util.config import load_config
 from chia.util.default_root import DEFAULT_ROOT_PATH
 from sqlalchemy.exc import OperationalError
 
-from monitor.configuration import Configuration
+from monitor.configuration import Configuration, read_config
 from monitor.collectors.ws_collector import WsCollector
-from monitor.collectors.rpc_collector import RpcCollector, RpcCollectorConfiguration
-from monitor.collectors.price_collector import PriceCollector, PriceCollectorConfiguration
+from monitor.collectors.rpc_collector import RpcCollector
+from monitor.collectors.price_collector import PriceCollector
 from monitor.database import ChiaEvent, session
 from monitor.exporter import ChiaExporter
 from monitor.logger import ChiaLogger
-from monitor.notifier import Notifier, NotifierConfiguration
+from monitor.notifier import Notifier
 
 chia_config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
 
@@ -105,45 +104,12 @@ async def aggregator(exporter: ChiaExporter, notifier: Optional[Notifier], confi
         notifier.stop()
 
 
-def read_config():
-    with open("config.json") as f:
-        config = json.load(f)
-    return config
-
-
 if __name__ == "__main__":
     initilize_logging()
     try:
-        config_json = read_config()
-    except:
-        logging.error(
-            "Failed to read config.json. Please copy the config-example.json to config.json and configure it to your preferences."
-        )
-        sys.exit(1)
-
-    try:
-        config = Configuration(
-            config_json["exporter_port"],
-            RpcCollectorConfiguration(
-                config_json["rpc_collector"]["refresh_interval_seconds"]
-            ),
-            PriceCollectorConfiguration(
-                config_json["price_collector"]["refresh_interval_seconds"]
-            ),
-            NotifierConfiguration(
-                config_json["notifications"]["enable"],
-                config_json["notifications"]["refresh_interval_seconds"],
-                config_json["notifications"]["status_interval_minutes"],
-                config_json["notifications"]["lost_plots_alert_threshold"],
-                config_json["notifications"]["disable_proof_found_alert"],
-                config_json["notifications"]["status_service_url"],
-                config_json["notifications"]["alert_service_url"]
-            )
-        )
-    except KeyError as ex:
-        logging.error(
-            f"Failed to validate config. Missing required key {ex}. Please compare the fields of your config.json with the config-example.json and fix all inconsistencies."
-        )
+        config = read_config()
+    except RuntimeError as ex:
+        logging.error(ex)
         sys.exit(1)
 
     exporter = ChiaExporter(config.exporter_port)

--- a/monitor/__main__.py
+++ b/monitor/__main__.py
@@ -21,7 +21,7 @@ from monitor.notifier import Notifier
 chia_config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
 
 
-def initilize_logging():
+def initialize_logging():
     handler = colorlog.StreamHandler()
     log_date_format = "%Y-%m-%dT%H:%M:%S"
     handler.setFormatter(
@@ -105,7 +105,7 @@ async def aggregator(exporter: ChiaExporter, notifier: Optional[Notifier], confi
 
 
 if __name__ == "__main__":
-    initilize_logging()
+    initialize_logging()
     try:
         config = read_config()
     except RuntimeError as ex:

--- a/monitor/__main__.py
+++ b/monitor/__main__.py
@@ -60,12 +60,13 @@ async def aggregator(exporter: ChiaExporter, notifier: Optional[Notifier], confi
     except Exception as e:
         logging.warning(f"Failed to create WebSocket collector. Continuing without it. {type(e).__name__}: {e}")
 
-    try:
-        logging.info("🔌 Creating Price Collector...")
-        price_collector = await PriceCollector.create(DEFAULT_ROOT_PATH, chia_config, event_queue,
-                                                      config.price_collector)
-    except Exception as e:
-        logging.warning(f"Failed to create Price collector. Continuing without it. {type(e).__name__}: {e}")
+    if config.price_collector.enable:
+        try:
+            logging.info("🔌 Creating Price Collector...")
+            price_collector = await PriceCollector.create(DEFAULT_ROOT_PATH, chia_config, event_queue,
+                                                          config.price_collector)
+        except Exception as e:
+            logging.warning(f"Failed to create Price collector. Continuing without it. {type(e).__name__}: {e}")
 
     if rpc_collector and ws_collector:
         logging.info("🚀 Starting monitoring loop!")
@@ -112,7 +113,7 @@ if __name__ == "__main__":
         logging.error(ex)
         sys.exit(1)
 
-    exporter = ChiaExporter(config.exporter_port)
+    exporter = ChiaExporter(config)
     if config.notifier.enable_notifications:
         notifier = Notifier(config.notifier)
     else:

--- a/monitor/collectors/price_collector.py
+++ b/monitor/collectors/price_collector.py
@@ -19,6 +19,7 @@ PRICE_API = f"https://api.coingecko.com/api/v3/simple/price?ids=chia&vs_currenci
 
 @dataclass(frozen=True)
 class PriceCollectorConfiguration:
+    enable: bool
     refresh_interval_seconds: int
 
 

--- a/monitor/configuration.py
+++ b/monitor/configuration.py
@@ -29,6 +29,7 @@ def read_config() -> Configuration:
                 config_json["rpc_collector"]["refresh_interval_seconds"]
             ),
             PriceCollectorConfiguration(
+                config_json["price_collector"]["enable"],
                 config_json["price_collector"]["refresh_interval_seconds"]
             ),
             NotifierConfiguration(

--- a/monitor/configuration.py
+++ b/monitor/configuration.py
@@ -1,7 +1,8 @@
+import json
 from dataclasses import dataclass
 
-from monitor.collectors.price_collector import PriceCollectorConfiguration
 from monitor.collectors.rpc_collector import RpcCollectorConfiguration
+from monitor.collectors.price_collector import PriceCollectorConfiguration
 from monitor.notifier import NotifierConfiguration
 
 
@@ -11,3 +12,37 @@ class Configuration:
     rpc_collector: RpcCollectorConfiguration
     price_collector: PriceCollectorConfiguration
     notifier: NotifierConfiguration
+
+
+def read_config() -> Configuration:
+    try:
+        with open("config.json") as f:
+            config_json = json.load(f)
+    except Exception:
+        raise RuntimeError("Failed to read config.json. "
+                           "Please copy the config-example.json to config.json and configure it to your preferences.")
+
+    try:
+        config = Configuration(
+            config_json["exporter_port"],
+            RpcCollectorConfiguration(
+                config_json["rpc_collector"]["refresh_interval_seconds"]
+            ),
+            PriceCollectorConfiguration(
+                config_json["price_collector"]["refresh_interval_seconds"]
+            ),
+            NotifierConfiguration(
+                config_json["notifications"]["enable"],
+                config_json["notifications"]["refresh_interval_seconds"],
+                config_json["notifications"]["status_interval_minutes"],
+                config_json["notifications"]["lost_plots_alert_threshold"],
+                config_json["notifications"]["disable_proof_found_alert"],
+                config_json["notifications"]["status_service_url"],
+                config_json["notifications"]["alert_service_url"]
+            )
+        )
+    except KeyError as ex:
+        raise RuntimeError(f"Failed to validate config. Missing required key {ex}. Please compare the fields of your "
+                           f"config.json with the config-example.json and fix all inconsistencies. ")
+
+    return config

--- a/monitor/configuration.py
+++ b/monitor/configuration.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+from monitor.collectors.price_collector import PriceCollectorConfiguration
+from monitor.collectors.rpc_collector import RpcCollectorConfiguration
+from monitor.notifier import NotifierConfiguration
+
+
+@dataclass(frozen=True)
+class Configuration:
+    exporter_port: int
+    rpc_collector: RpcCollectorConfiguration
+    price_collector: PriceCollectorConfiguration
+    notifier: NotifierConfiguration


### PR DESCRIPTION
Add option to disable price collector. Price collector is not always needed, especially if you have few instances of chia-monitor running. Then only one price collecting point is sufficient.

As I dived into the code, I thought that it would be good to improve the whole storage of configuration parameters, as more and more config options where passed by multiple arguments to their destination. What do you think about this?