### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,7 @@ RUN pipenv install
 COPY . .
 RUN pipenv run alembic upgrade head
 
+VOLUME [ "/chia-monitor/config.json", "/root/.chia" ]
+EXPOSE 8000
+
 ENTRYPOINT pipenv run python -m monitor

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM fsfe/pipenv:python-3.8
+
+WORKDIR /chia-monitor
+COPY Pipfile Pipfile.lock alembic.ini ./
+RUN pipenv install alembic
+RUN pipenv install
+COPY . .
+RUN pipenv run alembic upgrade head
+
+ENTRYPOINT pipenv run python -m monitor


### PR DESCRIPTION
Dockerfile that can be used to build a docker image to run chia-monitor in a container.

To be used in conjunction with #73 and following instructions from https://github.com/Chia-Network/chia-blockchain/wiki/Connecting-the-UI-to-a-remote-daemon.